### PR TITLE
Update solcast.mjs

### DIFF
--- a/mapped/control/solisExpFluxPeak.mjs
+++ b/mapped/control/solisExpFluxPeak.mjs
@@ -1,0 +1,49 @@
+import {Agility} from '/opt/agility/mapped/agility.mjs';
+let agility = new Agility();
+
+let obj = agility.battery.positionNow(false, '02:00');
+
+if (agility.isAlreadyRunning) {
+
+let status = 'UNKNOWN';
+if (obj.deficit > 0) {
+status = 'DEFICIT';
+}
+if (obj.deficit <= 0) {
+status = 'SURPLUS';
+}
+
+agility.logger.write('Checking Status for Export Management:');
+console.log('AGILITY STATUS:');
+console.log(obj.deficit);
+console.log(status);
+console.log('FORECAST LOAD:');
+console.log(obj.solis.load);
+console.log('BATTERY INCREMENT PER SLOT:');
+console.log(obj.battery.increasePerCharge.toFixed(2) + '%');
+console.log('BATTERY RESERVE:');
+console.log(obj.battery.availablePower);
+console.log('FORECAST SOLAR GENERATION:');
+console.log(obj.solcast.adjustedPrediction);
+console.log('FORECAST BATTERY SURPLUS:');
+console.log(obj.battery.availablePower - obj.solis.load);
+
+if (obj.battery.availablePower - obj.solis.load > obj.battery.powerAddedPerCharge) {
+status = 'EXPORTABLE BATTERY SURPLUS';
+let resp = await agility.solis.inverterDischarge(1);
+console.log(resp);
+agility.logger.write('EXPORTING FOR THIS TIMESLOT');
+}
+
+agility.logger.write(status);
+console.log(obj.battery.availablePower - obj.solis.load);
+console.log(obj.battery.powerAddedPerCharge);
+console.log(status);
+
+
+};
+
+console.log('=======================');
+agility.glsdb.close();
+
+

--- a/mapped/control/solisManageMode.mjs
+++ b/mapped/control/solisManageMode.mjs
@@ -1,0 +1,111 @@
+import {Agility} from '/opt/agility/mapped/agility.mjs';
+let agility = new Agility();
+
+let obj = agility.battery.positionNow(false, '22:30');
+
+if (agility.isAlreadyRunning) {
+
+let status = 'UNKNOWN';
+if (obj.deficit > 0) {
+status = 'DEFICIT';
+}
+if (obj.deficit <= 0) {
+status = 'SURPLUS';
+}
+
+agility.logger.write('Checking Status for Export Management:');
+console.log('AGILITY STATUS:');
+console.log(obj.deficit);
+console.log(status);
+console.log('FORECAST LOAD:');
+console.log(obj.solis.load);
+console.log('BATTERY RESERVE:');
+console.log(obj.battery.availablePower);
+console.log('FORECAST SOLAR GENERATION:');
+console.log(obj.solcast.adjustedPrediction);
+console.log('FORECAST BATTERY SURPLUS:');
+console.log(obj.battery.availablePower - obj.solis.load);
+
+if (obj.battery.availablePower - obj.solis.load < 0) {
+status = 'DEFICIT';
+}
+
+agility.logger.write(status);
+console.log(status);
+
+let url = '/v2/api/atRead';
+let body ={
+  inverterSn: agility.solis.inverterSn,
+  cid: 636
+};
+
+let resp = await agility.solis.api(url, body);
+console.log(resp);
+//resp.data.msg = 2;
+//resp.data.msg = 35;
+//resp.data.msg = 43;
+//resp.data.msg = 98;
+//resp.data.msg = 99;
+
+let newVal = parseInt(resp.data.msg);
+let ourBits = (newVal & 1) + (newVal & 64);
+
+console.log('Solis Bits');
+console.log(newVal.toString(2).padStart(16,'0'));
+console.log('Bits of Interest');
+console.log(ourBits.toString(2).padStart(16,'0'));
+
+if ((newVal & 1) + (newVal & 64) == 65) {
+console.log('Mode is UNKNOWN');
+newVal = resp.data.msg;
+console.log('Do nothing');
+}
+else if ((newVal & 1) + (newVal & 64) == 0) {
+console.log('Mode is UNKNOWN');
+newVal = resp.data.msg;
+console.log('Do nothing');
+}
+else if ((resp.data.msg & 1) == 1) {
+agility.logger.write('Mode is Self-Use');
+console.log('Mode is Self-Use');
+newVal = newVal + 64 - 1;
+console.log('If needed, SetCID 636 to ' + newVal + ' to change to Feed-in Priority mode');
+console.log(newVal.toString(2).padStart(16,'0'));
+if (status == 'SURPLUS' && (resp.data.msg & 1) == 1) {
+console.log('CHANGE MODE');
+agility.logger.write('CHANGE MODE');
+let resFIP = await agility.solis.controlAPI(636, newVal)
+agility.logger.write(resFIP)
+console.log(resFIP)
+}
+else {
+agility.logger.write('MODE ALREADY CORRECT');
+console.log('MODE ALREADY CORRECT');
+}
+}
+else if ((resp.data.msg & 64) == 64) {
+agility.logger.write('Mode is Feed-In Priority');
+console.log('Mode is Feed-In Priority');
+newVal = newVal - 64 + 1;
+console.log('Set CID 636 to ' + newVal + ' to change to Self-Use mode');
+console.log(newVal.toString(2).padStart(16,'0'));
+if (status == 'DEFICIT' && (resp.data.msg & 64) == 64) {
+agility.logger.write('CHANGE MODE');
+console.log('CHANGE MODE');
+let resSU = await agility.solis.controlAPI(636, newVal)
+console.log(resSU)
+agility.logger.write(resSU)
+}
+else {
+console.log('MODE CORRECT');
+}
+}
+
+}
+else {
+console.log('Agility is not running');
+}
+console.log('=======================');
+agility.glsdb.close();
+
+

--- a/mapped/solcast.mjs
+++ b/mapped/solcast.mjs
@@ -25,7 +25,7 @@
  |  limitations under the License.                                           |
  ----------------------------------------------------------------------------
 
- 1 February 2025
+ 19 February 2025
 
 */
 
@@ -142,7 +142,7 @@ let Solcast = class {
     //compare historical solcast original totals with solis historical actual totals
     // and calculate average percentage difference to apply
     // then reset into configuration document
-    
+   
     let count = 0;
     let totalP = 0;
     let totalA = 0;
@@ -312,20 +312,46 @@ let Solcast = class {
     }
     this.predictions.delete();
     let totals = {};
+    let totals_10 = {};
+    let totals_50 = {};
+    let totals_90 = {};
     for (let record of data.forecasts) {
       let d = this.date.at(record.period_end);
       let timeIndex = d.timeIndex;
       let dateIndex = d.dateIndex;
       let kw = +record.pv_estimate;
       let kwh = kw / 2;
+      let pv_10 = +record.pv_estimate10;
+      let pv_10kwh = pv_10 / 2;
+      let pv_50 = +record.pv_estimate;
+      let pv_50kwh = pv_50 / 2;
+      let pv_90 = +record.pv_estimate90;
+      let pv_90kwh = pv_90 / 2;
       if (!totals[dateIndex]) totals[dateIndex] = 0;
       totals[dateIndex] += kwh;
+      if (!totals_10[dateIndex]) totals_10[dateIndex] = 0;
+      totals_10[dateIndex] += pv_10kwh;
+      if (!totals_50[dateIndex]) totals_50[dateIndex] = 0;
+      totals_50[dateIndex] += pv_50kwh;
+      if (!totals_90[dateIndex]) totals_90[dateIndex] = 0;
+      totals_90[dateIndex] += pv_90kwh;
       let tot = totals[dateIndex];
       if (tot > 0) tot = tot.toFixed(4);
+      let tot_10 = totals_10[dateIndex];
+      if (tot_10 > 0) tot_10 = tot_10.toFixed(4);
+      let tot_50 = totals_50[dateIndex];
+      if (tot_50 > 0) tot_50 = tot_50.toFixed(4);
+      let tot_90 = totals_90[dateIndex];
+      if (tot_90 > 0) tot_90 = tot_90.toFixed(4);
       this.predictions.$([dateIndex, timeIndex]).document = {
-        kw: kw,
         kwh: kwh,
+        pv_10kwh: pv_10kwh,
+        pv_50kwh: pv_50kwh,
+        pv_90kwh: pv_90kwh,
         total: tot,
+        total_10: tot_10,
+        total_50: tot_50,
+        total_90: tot_90,
         day: d.dayText,
         time: d.timeText,
         month: d.monthText
@@ -349,8 +375,14 @@ let Solcast = class {
       if (dateIndex > todayDateIndex) {
         _this.totals.$(dateIndex).delete();
         let total = dateNode.lastChild.$('total').value;
+        let total_10 = dateNode.lastChild.$('total_10').value;
+        let total_50 = dateNode.lastChild.$('total_50').value;
+        let total_90 = dateNode.lastChild.$('total_90').value;
         _this.totals.$(dateIndex).document = {
           total: total,
+          total_10: total_10,
+          total_50: total_50,
+          total_90: total_90,
           month: d.monthText,
           day: d.dayText
         }


### PR DESCRIPTION
Add fields to retain Solcast 10th, 50th and 90th percentile forecasts and associated running and daily totals for future exploitation. Retain all existing agility fields but remove storage of kw in addition to kwh.